### PR TITLE
Use default lease durations as apiserver

### DIFF
--- a/pkg/leader_election/leader_election.go
+++ b/pkg/leader_election/leader_election.go
@@ -31,8 +31,6 @@ const (
 
 func RunLeaderElection() {
 
-	leaderElectionLease := 3 * time.Second
-
 	namespace := os.Getenv("NAMESPACE")
 	if namespace == "" {
 		namespace = "default"
@@ -87,10 +85,11 @@ func RunLeaderElection() {
 
 	go func() {
 		leaderelection.RunOrDie(context.Background(), leaderelection.LeaderElectionConfig{
-			Lock:          resLock,
-			LeaseDuration: leaderElectionLease,
-			RenewDeadline: leaderElectionLease * 2 / 3,
-			RetryPeriod:   leaderElectionLease / 3,
+			Lock: resLock,
+			// Default values: https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/v1alpha1/defaults.go#L37-L51
+			LeaseDuration: 15 * time.Second,
+			RenewDeadline: 10 * time.Second,
+			RetryPeriod:   2 * time.Second,
 			Callbacks: leaderelection.LeaderCallbacks{
 				OnStartedLeading: func(ctx context.Context) {
 					fmt.Println("Got leadership, now do your jobs")


### PR DESCRIPTION
With previous timeout, the Pods were restarting too often in minikube. 
Kubernetes apiserver using these values as default for leader election. https://github.com/kubernetes/apiserver/blob/e3c8fa95bba5a5ff9939a62c6ccd51ff3646b350/pkg/apis/config/v1alpha1/defaults.go#L37-L51

If there is no problem with increasing the timeout, we can use the default values of apiserver. 