### PR TITLE
Fix: All pod works as replica after Node/Cluster restart

### DIFF
--- a/hack/docker/postgres/10.2/scripts/primary/run.sh
+++ b/hack/docker/postgres/10.2/scripts/primary/run.sh
@@ -18,6 +18,14 @@ if [ ! -e "$PGDATA/PG_VERSION" ]; then
   fi
 fi
 
+# This node can become new leader while not able to create trigger file, So, left over recovery.conf from
+# last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
+# So, delete recovery.conf.
+if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
+    # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+  rm $PGDATA/recovery.conf
+fi
+
 # push base-backup
 if [ "$ARCHIVE" == "wal-g" ]; then
   # set walg ENV

--- a/hack/docker/postgres/10.2/scripts/primary/run.sh
+++ b/hack/docker/postgres/10.2/scripts/primary/run.sh
@@ -21,8 +21,8 @@ fi
 # This node can become new leader while not able to create trigger file, So, left over recovery.conf from
 # last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
 # So, delete recovery.conf.
-if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
-    # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
+if [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
+  # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
   rm $PGDATA/recovery.conf
 fi
 

--- a/hack/docker/postgres/10.2/scripts/primary/run.sh
+++ b/hack/docker/postgres/10.2/scripts/primary/run.sh
@@ -22,7 +22,7 @@ fi
 # last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
 # So, delete recovery.conf.
 if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
-    # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+    # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
   rm $PGDATA/recovery.conf
 fi
 

--- a/hack/docker/postgres/10.2/scripts/replica/run.sh
+++ b/hack/docker/postgres/10.2/scripts/replica/run.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eou pipefail
 
 echo "Running as Replica"
-
-mkdir -p "$PGDATA"
-rm -rf "$PGDATA"/*
-chmod 0700 "$PGDATA"
 
 # set password ENV
 export PGPASSWORD=${POSTGRES_PASSWORD:-postgres}
@@ -15,17 +11,30 @@ export ARCHIVE=${ARCHIVE:-}
 
 # Waiting for running Postgres
 while true; do
-  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   echo "Attempting pg_isready on primary"
+  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
+
 while true; do
-  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   echo "Attempting query on primary"
+  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
 
 # get basebackup
+mkdir -p "$PGDATA"
+rm -rf "$PGDATA"/*
+chmod 0700 "$PGDATA"
+
 pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --host="$PRIMARY_HOST"
 
 # setup recovery.conf
@@ -55,7 +64,7 @@ mv /tmp/postgresql.conf "$PGDATA/postgresql.conf"
 # push base-backup
 if [ "$ARCHIVE" == "wal-g" ]; then
   # set walg ENV
-   CRED_PATH="/srv/wal-g/archive/secrets"
+  CRED_PATH="/srv/wal-g/archive/secrets"
 
   if [[ ${ARCHIVE_S3_PREFIX} != "" ]]; then
     export WALE_S3_PREFIX="$ARCHIVE_S3_PREFIX"

--- a/hack/docker/postgres/10.2/scripts/replica/run.sh
+++ b/hack/docker/postgres/10.2/scripts/replica/run.sh
@@ -14,8 +14,9 @@ while true; do
   echo "Attempting pg_isready on primary"
   pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done
@@ -24,8 +25,9 @@ while true; do
   echo "Attempting query on primary"
   psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done

--- a/hack/docker/postgres/10.6/scripts/primary/run.sh
+++ b/hack/docker/postgres/10.6/scripts/primary/run.sh
@@ -18,6 +18,14 @@ if [ ! -e "$PGDATA/PG_VERSION" ]; then
   fi
 fi
 
+# This node can become new leader while not able to create trigger file, So, left over recovery.conf from
+# last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
+# So, delete recovery.conf.
+if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
+    # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+  rm $PGDATA/recovery.conf
+fi
+
 # push base-backup
 if [ "$ARCHIVE" == "wal-g" ]; then
   # set walg ENV

--- a/hack/docker/postgres/10.6/scripts/primary/run.sh
+++ b/hack/docker/postgres/10.6/scripts/primary/run.sh
@@ -21,8 +21,8 @@ fi
 # This node can become new leader while not able to create trigger file, So, left over recovery.conf from
 # last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
 # So, delete recovery.conf.
-if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
-    # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
+if [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
+  # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
   rm $PGDATA/recovery.conf
 fi
 

--- a/hack/docker/postgres/10.6/scripts/primary/run.sh
+++ b/hack/docker/postgres/10.6/scripts/primary/run.sh
@@ -22,7 +22,7 @@ fi
 # last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
 # So, delete recovery.conf.
 if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
-    # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+    # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
   rm $PGDATA/recovery.conf
 fi
 

--- a/hack/docker/postgres/10.6/scripts/replica/run.sh
+++ b/hack/docker/postgres/10.6/scripts/replica/run.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eou pipefail
 
 echo "Running as Replica"
-
-mkdir -p "$PGDATA"
-rm -rf "$PGDATA"/*
-chmod 0700 "$PGDATA"
 
 # set password ENV
 export PGPASSWORD=${POSTGRES_PASSWORD:-postgres}
@@ -15,17 +11,30 @@ export ARCHIVE=${ARCHIVE:-}
 
 # Waiting for running Postgres
 while true; do
-  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   echo "Attempting pg_isready on primary"
+  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
+
 while true; do
-  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   echo "Attempting query on primary"
+  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
 
 # get basebackup
+mkdir -p "$PGDATA"
+rm -rf "$PGDATA"/*
+chmod 0700 "$PGDATA"
+
 pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --host="$PRIMARY_HOST"
 
 # setup recovery.conf

--- a/hack/docker/postgres/10.6/scripts/replica/run.sh
+++ b/hack/docker/postgres/10.6/scripts/replica/run.sh
@@ -14,8 +14,9 @@ while true; do
   echo "Attempting pg_isready on primary"
   pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done
@@ -24,8 +25,9 @@ while true; do
   echo "Attempting query on primary"
   psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done

--- a/hack/docker/postgres/11.1/scripts/primary/run.sh
+++ b/hack/docker/postgres/11.1/scripts/primary/run.sh
@@ -18,6 +18,14 @@ if [ ! -e "$PGDATA/PG_VERSION" ]; then
   fi
 fi
 
+# This node can become new leader while not able to create trigger file, So, left over recovery.conf from
+# last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
+# So, delete recovery.conf.
+if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
+    # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+  rm $PGDATA/recovery.conf
+fi
+
 # push base-backup
 if [ "$ARCHIVE" == "wal-g" ]; then
   # set walg ENV

--- a/hack/docker/postgres/11.1/scripts/primary/run.sh
+++ b/hack/docker/postgres/11.1/scripts/primary/run.sh
@@ -21,8 +21,8 @@ fi
 # This node can become new leader while not able to create trigger file, So, left over recovery.conf from
 # last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
 # So, delete recovery.conf.
-if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
-    # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
+if [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
+  # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
   rm $PGDATA/recovery.conf
 fi
 

--- a/hack/docker/postgres/11.1/scripts/primary/run.sh
+++ b/hack/docker/postgres/11.1/scripts/primary/run.sh
@@ -22,7 +22,7 @@ fi
 # last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
 # So, delete recovery.conf.
 if  [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
-    # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+    # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
   rm $PGDATA/recovery.conf
 fi
 

--- a/hack/docker/postgres/11.1/scripts/replica/run.sh
+++ b/hack/docker/postgres/11.1/scripts/replica/run.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eou pipefail
 
 echo "Running as Replica"
-
-mkdir -p "$PGDATA"
-rm -rf "$PGDATA"/*
-chmod 0700 "$PGDATA"
 
 # set password ENV
 export PGPASSWORD=${POSTGRES_PASSWORD:-postgres}
@@ -15,17 +11,30 @@ export ARCHIVE=${ARCHIVE:-}
 
 # Waiting for running Postgres
 while true; do
-  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   echo "Attempting pg_isready on primary"
+  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
+
 while true; do
-  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   echo "Attempting query on primary"
+  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
 
 # get basebackup
+mkdir -p "$PGDATA"
+rm -rf "$PGDATA"/*
+chmod 0700 "$PGDATA"
+
 pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --host="$PRIMARY_HOST"
 
 # setup recovery.conf
@@ -55,7 +64,7 @@ mv /tmp/postgresql.conf "$PGDATA/postgresql.conf"
 # push base-backup
 if [ "$ARCHIVE" == "wal-g" ]; then
   # set walg ENV
-   CRED_PATH="/srv/wal-g/archive/secrets"
+  CRED_PATH="/srv/wal-g/archive/secrets"
 
   if [[ ${ARCHIVE_S3_PREFIX} != "" ]]; then
     export WALE_S3_PREFIX="$ARCHIVE_S3_PREFIX"

--- a/hack/docker/postgres/11.1/scripts/replica/run.sh
+++ b/hack/docker/postgres/11.1/scripts/replica/run.sh
@@ -14,8 +14,9 @@ while true; do
   echo "Attempting pg_isready on primary"
   pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done
@@ -24,8 +25,9 @@ while true; do
   echo "Attempting query on primary"
   psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done

--- a/hack/docker/postgres/9.6.7/scripts/primary/run.sh
+++ b/hack/docker/postgres/9.6.7/scripts/primary/run.sh
@@ -18,6 +18,14 @@ if [ ! -e "$PGDATA/PG_VERSION" ]; then
   fi
 fi
 
+# This node can become new leader while not able to create trigger file, So, left over recovery.conf from
+# last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
+# So, delete recovery.conf.
+if [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
+  # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+  rm $PGDATA/recovery.conf
+fi
+
 # push base-backup
 if [ "$ARCHIVE" == "wal-g" ]; then
   # set walg ENV

--- a/hack/docker/postgres/9.6.7/scripts/primary/run.sh
+++ b/hack/docker/postgres/9.6.7/scripts/primary/run.sh
@@ -22,7 +22,7 @@ fi
 # last bootup (when this node was standby) may exists. And, that will force this node to become STANDBY.
 # So, delete recovery.conf.
 if [[ -e $PGDATA/recovery.conf ]] && [[ $(cat $PGDATA/recovery.conf | grep -c "primary_conninfo") -gt 0 ]]; then
-  # recovery.conf file exists and contains standby_mode = on. So, this is left over from previous standby state.
+  # recovery.conf file exists and contains "primary_conninfo". So, this is left over from previous standby state.
   rm $PGDATA/recovery.conf
 fi
 

--- a/hack/docker/postgres/9.6.7/scripts/replica/run.sh
+++ b/hack/docker/postgres/9.6.7/scripts/replica/run.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+set -eou pipefail
 
 echo "Running as Replica"
-
-mkdir -p "$PGDATA"
-rm -rf "$PGDATA"/*
-chmod 0700 "$PGDATA"
 
 # set password ENV
 export PGPASSWORD=${POSTGRES_PASSWORD:-postgres}
@@ -15,17 +11,30 @@ export ARCHIVE=${ARCHIVE:-}
 
 # Waiting for running Postgres
 while true; do
-  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   echo "Attempting pg_isready on primary"
+  pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
+
 while true; do
-  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   echo "Attempting query on primary"
+  psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
+  # check if current pod became leader itself
+  if [[ -e "/tmp/leader/leader-elected" ]]; then
+    exit 0
+  fi
   sleep 2
 done
 
 # get basebackup
+mkdir -p "$PGDATA"
+rm -rf "$PGDATA"/*
+chmod 0700 "$PGDATA"
+
 pg_basebackup -X fetch --no-password --pgdata "$PGDATA" --username=postgres --host="$PRIMARY_HOST"
 
 # setup recovery.conf

--- a/hack/docker/postgres/9.6.7/scripts/replica/run.sh
+++ b/hack/docker/postgres/9.6.7/scripts/replica/run.sh
@@ -14,8 +14,9 @@ while true; do
   echo "Attempting pg_isready on primary"
   pg_isready --host="$PRIMARY_HOST" --timeout=2 &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done
@@ -24,8 +25,9 @@ while true; do
   echo "Attempting query on primary"
   psql -h "$PRIMARY_HOST" --no-password --username=postgres --command="select now();" &>/dev/null && break
   # check if current pod became leader itself
-  if [[ -e "/tmp/leader/leader-elected" ]]; then
-    exit 0
+  if [[ -e "/tmp/pg-failover-trigger" ]]; then
+    echo "Postgres promotion trigger_file found. Running primary run script"
+    exec /scripts/primary/run.sh
   fi
   sleep 2
 done

--- a/pkg/leader_election/leader_election.go
+++ b/pkg/leader_election/leader_election.go
@@ -145,9 +145,6 @@ func RunLeaderElection() {
 							if !ioutil.WriteString("/tmp/pg-failover-trigger", "") {
 								log.Fatalln("Failed to create trigger file")
 							}
-							if !ioutil.WriteString("/tmp/leader/leader-elected", "") {
-								log.Println("Failed to create leader-election trigger file")
-							}
 						}
 					}
 				},

--- a/pkg/leader_election/leader_election.go
+++ b/pkg/leader_election/leader_election.go
@@ -145,6 +145,9 @@ func RunLeaderElection() {
 							if !ioutil.WriteString("/tmp/pg-failover-trigger", "") {
 								log.Fatalln("Failed to create trigger file")
 							}
+							if !ioutil.WriteString("/tmp/leader/leader-elected", "") {
+								log.Println("Failed to create leader-election trigger file")
+							}
 						}
 					}
 				},


### PR DESCRIPTION
This is done by watching a `leader-election` trigger file from the waiting loop. 
Fixes: https://github.com/kubedb/project/issues/330

Also, Do not delete data directory until primary is reachable. xref: https://github.com/kubedb/project/issues/405 
TODO: Find a better solution for Standby Nodes, ie, connect standby nodes to primary without deleting data directory.  xref: https://github.com/kubedb/project/issues/385