### PR TITLE
Add shared memory /dev/shm volume

### DIFF
--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -505,7 +505,7 @@ func upsertShm(statefulSet *apps.StatefulSet, postgress *api.Postgres) *apps.Sta
 			}
 			volumes := statefulSet.Spec.Template.Spec.Volumes
 			volumes = core_util.UpsertVolume(volumes, configVolume)
-			statefulSet.Spec.Template.Spec.Containers[i].Volumes = volumes
+			statefulSet.Spec.Template.Spec.Containers.Volumes = volumes
 			return statefulSet
 		}
 	}

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -505,7 +505,7 @@ func upsertShm(statefulSet *apps.StatefulSet, postgress *api.Postgres) *apps.Sta
 			}
 			volumes := statefulSet.Spec.Template.Spec.Volumes
 			volumes = core_util.UpsertVolume(volumes, configVolume)
-			statefulSet.Spec.Template.Spec.Containers.Volumes = volumes
+			statefulSet.Spec.Template.Spec.Volumes = volumes
 			return statefulSet
 		}
 	}

--- a/pkg/controller/statefulset.go
+++ b/pkg/controller/statefulset.go
@@ -122,6 +122,7 @@ func (c *Controller) ensureStatefulSet(
 			}
 		}
 
+		in = upsertShm(in, postgres)
 		in = upsertDataVolume(in, postgres)
 		in = upsertCustomConfig(in, postgres)
 
@@ -477,6 +478,34 @@ func upsertInitWalSecret(statefulSet *apps.StatefulSet, secretName string) *apps
 			volumes := statefulSet.Spec.Template.Spec.Volumes
 			volumes = core_util.UpsertVolume(volumes, volume)
 			statefulSet.Spec.Template.Spec.Volumes = volumes
+			return statefulSet
+		}
+	}
+	return statefulSet
+}
+
+func upsertShm(statefulSet *apps.StatefulSet, postgress *api.Postgres) *apps.StatefulSet {
+	for i, container := range statefulSet.Spec.Template.Spec.Containers {
+		if container.Name == api.ResourceSingularPostgres {
+			volumeMount := core.VolumeMount{
+				Name:      "shared-memory",
+				MountPath: "/dev/shm",
+			}
+			volumeMounts := container.VolumeMounts
+			volumeMounts = core_util.UpsertVolumeMount(volumeMounts, volumeMount)
+			statefulSet.Spec.Template.Spec.Containers[i].VolumeMounts = volumeMounts
+
+			configVolume := core.Volume{
+				Name: "shared-memory",
+				VolumeSource: core.VolumeSource{
+					EmptyDir: &core.EmptyDirVolumeSource{
+						Medium: core.StorageMediumMemory,
+					},
+				},
+			}
+			volumes := statefulSet.Spec.Template.Spec.Volumes
+			volumes = core_util.UpsertVolume(volumes, configVolume)
+			statefulSet.Spec.Template.Spec.Containers[i].Volumes = volumes
 			return statefulSet
 		}
 	}


### PR DESCRIPTION
By default the docker has limit in 64MB for `/dev/shm` set. Which later used for postgres for it's shared memory settings.  That means - whatever we set in the `user.conf` for shared_buffers - won't be used in full capacity and Postgres will with following errors 
```
ERROR:  could not resize shared memory segment "/PostgreSQL.1624162460" to 50438144 bytes: No space left on device
```

This PR should add default `EmptyFolder` in-memory (tmpfs) in place of `/dev/shm` to prevent this.

Keep in mind that this was not properly tested and need some additional love and care before can be merged anywhere 