### PR TITLE
feat: allow changes to nodeSelector

### DIFF
--- a/pkg/admission/validator.go
+++ b/pkg/admission/validator.go
@@ -373,7 +373,6 @@ var preconditionSpecFields = []string{
 	"spec.storageType",
 	"spec.storage",
 	"spec.init",
-	"spec.podTemplate.spec.nodeSelector",
 }
 
 func preconditionFailedError() error {


### PR DESCRIPTION
This makes it possible to patch the underlying StatefulSet to change the nodeSelector to schedule
pods on alternate nodes. Due to kubernetes/kubernetes#57838, the pods will have to be deleted
manually in order for the new nodeSelector to be used.

This addresses kubedb/project#649