### PR TITLE
fix operator hang

### DIFF
--- a/pkg/controller/workqueue.go
+++ b/pkg/controller/workqueue.go
@@ -29,6 +29,10 @@ func (c *Controller) initWatcher() {
 	c.pgQueue = queue.New("Postgres", c.MaxNumRequeues, c.NumThreads, c.runPostgres)
 	c.pgLister = c.KubedbInformerFactory.Kubedb().V1alpha1().Postgreses().Lister()
 	c.pgInformer.AddEventHandler(queue.NewObservableUpdateHandler(c.pgQueue.GetQueue(), true))
+
+	// listen sub resources sts
+	stsInformer := c.KubeInformerFactory.Apps().V1().StatefulSets().Informer()
+	stsInformer.AddEventHandler(queue.NewObservableUpdateHandler(c.pgQueue.GetQueue(), false))
 }
 
 func (c *Controller) runPostgres(key string) error {


### PR DESCRIPTION
I have use kubedb-operator to create postgres cluster, I want to create a cluster with 8C16G, but it's not enough resources to created, then it will hang.  I can't even delete the pg.

I have change the code, It only wait the sts to created, but not ready. It should wait sts ready next time. Just watch, not wait.

Signed-off-by: longhui.li <longhui.li@woqutech.com>