### PR TITLE
Prepare for release v0.14.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20200922210707-59bab27e5d41
 	kmodules.xyz/offshoot-api v0.0.0-20201027120238-b5c30f198112
 	kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
-	kubedb.dev/apimachinery v0.14.0-beta.6
-	kubedb.dev/pg-leader-election v0.2.0-beta.6
+	kubedb.dev/apimachinery v0.14.0-rc.1
+	kubedb.dev/pg-leader-election v0.2.0-rc.1
 	stash.appscode.dev/apimachinery v0.11.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1593,10 +1593,10 @@ kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e h1:NASVP0dOE5Zdlq+3Op7Fh2
 kmodules.xyz/prober v0.0.0-20200922212142-743a6514664e/go.mod h1:AZ58K5hrxkkNPf8tM+UWeZjtNG3/mn192nKcUyC93F8=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de h1:uWgv78OoOWx9eQdu6SEkPopvbpnL8WxZEMNd3/Oye2w=
 kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de/go.mod h1:5A8s2nvrNAZGrt0OlsiiuZIik3xWyKW6+ZSwgljIm78=
-kubedb.dev/apimachinery v0.14.0-beta.6 h1:HuM/2TRM/IFlssB9j/Ri8VS9EEiiuOWVAHdWpZq2R9E=
-kubedb.dev/apimachinery v0.14.0-beta.6/go.mod h1:em0oWivOXYZUMj4fZ4wLIIfr86eyzogAcZ6GDcnplvY=
-kubedb.dev/pg-leader-election v0.2.0-beta.6 h1:qR525XM0n6jh7Gbfu20Nzbs+WhAYOkhNXe1TU8gG9ec=
-kubedb.dev/pg-leader-election v0.2.0-beta.6/go.mod h1:m7o/E2ty7ec5zJNAa08+dgqq1MkP35FbxhXFqNrFbN4=
+kubedb.dev/apimachinery v0.14.0-rc.1 h1:Bj0jMmfX+eM0r9ppwoEjtrJtDvuQNGiyoDzULf67Amw=
+kubedb.dev/apimachinery v0.14.0-rc.1/go.mod h1:em0oWivOXYZUMj4fZ4wLIIfr86eyzogAcZ6GDcnplvY=
+kubedb.dev/pg-leader-election v0.2.0-rc.1 h1:ohQVn7MMm9Y4jcrQQLivjiNHK/dooKmydhfimbe0yT0=
+kubedb.dev/pg-leader-election v0.2.0-rc.1/go.mod h1:m7o/E2ty7ec5zJNAa08+dgqq1MkP35FbxhXFqNrFbN4=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1164,7 +1164,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20200922211931-8337935590de
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.14.0-beta.6
+# kubedb.dev/apimachinery v0.14.0-rc.1
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1
@@ -1211,7 +1211,7 @@ kubedb.dev/apimachinery/pkg/controller/initializer/stash
 kubedb.dev/apimachinery/pkg/controller/statefulset
 kubedb.dev/apimachinery/pkg/eventer
 kubedb.dev/apimachinery/pkg/validator
-# kubedb.dev/pg-leader-election v0.2.0-beta.6
+# kubedb.dev/pg-leader-election v0.2.0-rc.1
 kubedb.dev/pg-leader-election/pkg/leader_election
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/18
Signed-off-by: 1gtm <1gtm@appscode.com>