### PR TITLE
Prepare for release v0.15.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,8 +36,8 @@ require (
 	kmodules.xyz/objectstore-api v0.0.0-20201105133858-cbb2af88d50a
 	kmodules.xyz/offshoot-api v0.0.0-20201105074700-8675f5f686f2
 	kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
-	kubedb.dev/apimachinery v0.15.2-0.20201208072031-429b2e10bc9e
-	kubedb.dev/pg-leader-election v0.3.1
+	kubedb.dev/apimachinery v0.15.2
+	kubedb.dev/pg-leader-election v0.3.2
 	stash.appscode.dev/apimachinery v0.11.7
 
 )

--- a/go.sum
+++ b/go.sum
@@ -1626,10 +1626,10 @@ kmodules.xyz/prober v0.0.0-20201105074402-a243b3a27fd8 h1:UJb5lHQVFKbmlgmRLq5IWJ
 kmodules.xyz/prober v0.0.0-20201105074402-a243b3a27fd8/go.mod h1:2eN8X5Wq7/AAgE5AWMAX8T0lE51HZiYEldG2RQuouX4=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6 h1:9+EIwxUrXrM8QD9rC1Fg+6CQK0vPniFO3ClaKih010M=
 kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6/go.mod h1:xLgewoOzwR5ZrVOHQ2SR0P4E7tgCyBWbYlUawEXgeF4=
-kubedb.dev/apimachinery v0.15.2-0.20201208072031-429b2e10bc9e h1:iDeK7uMIvrTN0hDJijDPl+AHc5ajSM/XxKiXmpWhn9Q=
-kubedb.dev/apimachinery v0.15.2-0.20201208072031-429b2e10bc9e/go.mod h1:D/YBfZpBxWZLVw0V4hNIZt1zOb+RVGXDke4a8DDm8jI=
-kubedb.dev/pg-leader-election v0.3.1 h1:EddyPpXWLszB1E6Puc/t6oA20L5+5Pku4zHnOs6qmDw=
-kubedb.dev/pg-leader-election v0.3.1/go.mod h1:fD4oRH/bzXt1PXBKFwYW5Ogi/qDrg4qn3MA9kYUYvFY=
+kubedb.dev/apimachinery v0.15.2 h1:UkZK33TZxMHmFCVmpBKdKXsR1+vciD6dmEI5hySy2kI=
+kubedb.dev/apimachinery v0.15.2/go.mod h1:D/YBfZpBxWZLVw0V4hNIZt1zOb+RVGXDke4a8DDm8jI=
+kubedb.dev/pg-leader-election v0.3.2 h1:VTC1ex1d5pBqCkOd+l6h9fpDqjfyRKsAF2eL82w4+9w=
+kubedb.dev/pg-leader-election v0.3.2/go.mod h1:nFQrPM9XPkFKYxXJDjTD2YPAfMMcpQRW9eTLx4jcUrE=
 modernc.org/cc v1.0.0/go.mod h1:1Sk4//wdnYJiUIxnW8ddKpaOJCF37yAdqYnkxUpaYxw=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/constants.go
@@ -251,25 +251,13 @@ var (
 		core.ResourceCPU:    resource.MustParse(".250"),
 		core.ResourceMemory: resource.MustParse("512Mi"),
 	}
-	defaultResourceRequests = core.ResourceList{
-		core.ResourceCPU:    resource.MustParse(".100"),
-		core.ResourceMemory: resource.MustParse("256Mi"),
-	}
 
 	defaultElasticsearchResourceLimits = core.ResourceList{
 		core.ResourceCPU:    resource.MustParse(".600"),
 		core.ResourceMemory: resource.MustParse("512Mi"),
 	}
-	defaultElasticsearchResourceRequests = core.ResourceList{
-		core.ResourceCPU:    resource.MustParse(".300"),
-		core.ResourceMemory: resource.MustParse("256Mi"),
-	}
 
 	defaultMySQLResourceLimits = core.ResourceList{
-		core.ResourceCPU:    resource.MustParse(".500"),
-		core.ResourceMemory: resource.MustParse("1024Mi"),
-	}
-	defaultMySQLResourceRequests = core.ResourceList{
 		core.ResourceCPU:    resource.MustParse(".500"),
 		core.ResourceMemory: resource.MustParse("1024Mi"),
 	}

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/elasticsearch_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/elasticsearch_helpers.go
@@ -279,21 +279,21 @@ func (e *Elasticsearch) SetDefaults(esVersion *v1alpha1.ElasticsearchVersion, to
 		if e.Spec.Topology.Ingest.Prefix == "" {
 			e.Spec.Topology.Ingest.Prefix = ElasticsearchIngestNodePrefix
 		}
-		setDefaultResourceLimits(&e.Spec.Topology.Ingest.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceRequests)
+		setDefaultResourceLimits(&e.Spec.Topology.Ingest.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceLimits)
 
 		// Default to "data"
 		if e.Spec.Topology.Data.Prefix == "" {
 			e.Spec.Topology.Data.Prefix = ElasticsearchDataNodePrefix
 		}
-		setDefaultResourceLimits(&e.Spec.Topology.Data.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceRequests)
+		setDefaultResourceLimits(&e.Spec.Topology.Data.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceLimits)
 
 		// Default to "master"
 		if e.Spec.Topology.Master.Prefix == "" {
 			e.Spec.Topology.Master.Prefix = ElasticsearchMasterNodePrefix
 		}
-		setDefaultResourceLimits(&e.Spec.Topology.Master.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceRequests)
+		setDefaultResourceLimits(&e.Spec.Topology.Master.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceLimits)
 	} else {
-		setDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceRequests)
+		setDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, defaultElasticsearchResourceLimits, defaultElasticsearchResourceLimits)
 	}
 
 	e.setDefaultAffinity(&e.Spec.PodTemplate, e.OffshootSelectors(), topology)

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/etcd_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/etcd_helpers.go
@@ -153,7 +153,7 @@ func (e *Etcd) SetDefaults() {
 	}
 
 	e.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&e.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 func (e *EtcdSpec) GetPersistentSecrets() []string {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mariadb_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mariadb_helpers.go
@@ -170,7 +170,7 @@ func (m *MariaDB) SetDefaults() {
 
 	m.Spec.setDefaultProbes()
 	m.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 func (m *MariaDBSpec) setDefaultProbes() {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/memcached_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/memcached_helpers.go
@@ -150,7 +150,7 @@ func (m *Memcached) SetDefaults() {
 	}
 
 	m.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 func (m *MemcachedSpec) GetPersistentSecrets() []string {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mongodb_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mongodb_helpers.go
@@ -363,9 +363,9 @@ func (m *MongoDB) SetDefaults(mgVersion *v1alpha1.MongoDBVersion, topology *core
 	}
 
 	if m.Spec.ShardTopology != nil {
-		setDefaultResourceLimits(&m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
-		setDefaultResourceLimits(&m.Spec.ShardTopology.Shard.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
-		setDefaultResourceLimits(&m.Spec.ShardTopology.ConfigServer.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+		setDefaultResourceLimits(&m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+		setDefaultResourceLimits(&m.Spec.ShardTopology.Shard.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
+		setDefaultResourceLimits(&m.Spec.ShardTopology.ConfigServer.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 
 		if m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Lifecycle == nil {
 			m.Spec.ShardTopology.Mongos.PodTemplate.Spec.Lifecycle = new(core.Lifecycle)
@@ -425,7 +425,7 @@ func (m *MongoDB) SetDefaults(mgVersion *v1alpha1.MongoDBVersion, topology *core
 		// set default affinity (PodAntiAffinity)
 		m.setDefaultAffinity(m.Spec.PodTemplate, m.OffshootSelectors(), topology)
 
-		setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+		setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 	}
 
 	m.SetTLSDefaults()

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mysql_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/mysql_helpers.go
@@ -183,7 +183,7 @@ func (m *MySQL) SetDefaults() {
 	m.Spec.Monitor.SetDefaults()
 
 	m.SetTLSDefaults()
-	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultMySQLResourceLimits, defaultMySQLResourceRequests)
+	setDefaultResourceLimits(&m.Spec.PodTemplate.Spec.Resources, defaultMySQLResourceLimits, defaultMySQLResourceLimits)
 }
 
 func (m *MySQL) SetTLSDefaults() {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/perconaxtradb_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/perconaxtradb_helpers.go
@@ -171,7 +171,7 @@ func (p *PerconaXtraDB) SetDefaults() {
 
 	p.Spec.setDefaultProbes()
 	p.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 // setDefaultProbes sets defaults only when probe fields are nil.

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/pgbouncer_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/pgbouncer_helpers.go
@@ -155,7 +155,7 @@ func (p *PgBouncer) SetDefaults() {
 	p.Spec.Monitor.SetDefaults()
 
 	p.SetTLSDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 func (p *PgBouncer) SetTLSDefaults() {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/postgres_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/postgres_helpers.go
@@ -176,7 +176,7 @@ func (p *Postgres) SetDefaults() {
 	}
 
 	p.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 func (e *PostgresSpec) GetPersistentSecrets() []string {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/proxysql_helpers.go
@@ -151,7 +151,7 @@ func (p *ProxySQL) SetDefaults() {
 	}
 
 	p.Spec.Monitor.SetDefaults()
-	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&p.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 func (p *ProxySQLSpec) GetPersistentSecrets() []string {

--- a/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/redis_helpers.go
+++ b/vendor/kubedb.dev/apimachinery/apis/kubedb/v1alpha2/redis_helpers.go
@@ -196,7 +196,7 @@ func (r *Redis) SetDefaults(topology *core_util.Topology) {
 	r.Spec.Monitor.SetDefaults()
 
 	r.SetTLSDefaults()
-	setDefaultResourceLimits(&r.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceRequests)
+	setDefaultResourceLimits(&r.Spec.PodTemplate.Spec.Resources, defaultResourceLimits, defaultResourceLimits)
 }
 
 func (r *Redis) SetTLSDefaults() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1182,7 +1182,7 @@ kmodules.xyz/prober/api/v1
 # kmodules.xyz/webhook-runtime v0.0.0-20201105073856-2dc7382b88c6
 kmodules.xyz/webhook-runtime/admission/v1beta1
 kmodules.xyz/webhook-runtime/registry/admissionreview/v1beta1
-# kubedb.dev/apimachinery v0.15.2-0.20201208072031-429b2e10bc9e
+# kubedb.dev/apimachinery v0.15.2
 kubedb.dev/apimachinery/apis
 kubedb.dev/apimachinery/apis/autoscaling
 kubedb.dev/apimachinery/apis/autoscaling/v1alpha1
@@ -1229,7 +1229,7 @@ kubedb.dev/apimachinery/pkg/controller/initializer/stash
 kubedb.dev/apimachinery/pkg/controller/statefulset
 kubedb.dev/apimachinery/pkg/eventer
 kubedb.dev/apimachinery/pkg/validator
-# kubedb.dev/pg-leader-election v0.3.1
+# kubedb.dev/pg-leader-election v0.3.2
 kubedb.dev/pg-leader-election/pkg/leader_election
 # sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.12.10
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/26
Signed-off-by: 1gtm <1gtm@appscode.com>